### PR TITLE
Add a ConflictError class to shuttle.exceptions

### DIFF
--- a/hubble_shuttle/exceptions.py
+++ b/hubble_shuttle/exceptions.py
@@ -29,6 +29,10 @@ class BadRequestError(HTTPClientError):
 class NotFoundError(HTTPClientError):
     pass
 
+# For 409 HTTP errors
+class ConflictError(HTTPClientError):
+    pass
+
 # For 500 HTTP errors
 class InternalServerError(HTTPServerError):
     pass
@@ -41,6 +45,7 @@ HTTP_STATUS_CODE_CLASS_ERRORS = {
 HTTP_STATUS_CODE_ERRORS = {
     400: BadRequestError,
     404: NotFoundError,
+    409: ConflictError,
     500: InternalServerError,
 }
 

--- a/hubble_shuttle/tests/tests_shuttle_api.py
+++ b/hubble_shuttle/tests/tests_shuttle_api.py
@@ -121,6 +121,13 @@ class ShuttleAPITest(TestCase):
         self.assertEqual("ShuttleAPITestClient", cm.exception.service_name, "Sets the service name")
         self.assertEqual("/status/404", cm.exception.source, "Sets the error source")
 
+    def test_get_409_http_error(self):
+        with self.assertRaises(hubble_shuttle.exceptions.ConflictError) as cm:
+            ShuttleAPITestClient().http_get("/status/409")
+        self.assertEqual(409, cm.exception.internal_status_code, "Returns the error status code")
+        self.assertEqual("ShuttleAPITestClient", cm.exception.service_name, "Sets the service name")
+        self.assertEqual("/status/409", cm.exception.source, "Sets the error source")
+
     def test_get_499_http_error(self):
         with self.assertRaises(hubble_shuttle.exceptions.HTTPClientError) as cm:
             ShuttleAPITestClient().http_get("/status/499")


### PR DESCRIPTION
This is an elegant way to handle exceptions that come from a duplicate or multiple objects found and any other 409 errors