### PR TITLE
Sc 11482 drop support for python 3 7 in shuttle

### DIFF
--- a/Dockerfile-3.7
+++ b/Dockerfile-3.7
@@ -1,7 +1,0 @@
-FROM python:3.7-alpine
-
-RUN mkdir /src
-WORKDIR /src
-COPY . .
-
-RUN python -m pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export PYTHON_VERSIONS := 3.7 3.8 3.9
+export PYTHON_VERSIONS := 3.8 3.9
 
 .PHONY: dev-build
 dev-build: ## Create the docker image for you dev environment.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install hubble_shuttle
 
 ### Supported Python versions
 
-Shuttle is build and tested with Python 3.5, 3.6, 3.7, and 3.8.
+Shuttle is build and tested with Python 3.8, and 3.9.
 
 ## Client-level configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,6 @@
 version: "3"
 
 services:
-  hubble-shuttle-3.7:
-    container_name: hubble-shuttle-3.7
-    build:
-      context: .
-      dockerfile: Dockerfile-3.7
-    volumes:
-      - .:/src
-    depends_on:
-      - test_http_server
   hubble-shuttle-3.8:
     container_name: hubble-shuttle-3.8
     build:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="hubble_shuttle",
-    version="0.3.0",
+    version="0.4.0",
     author="HubbleHQ",
     author_email="dev@hubblehq.com",
     description="Hubble's Shuttle",

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
Remove support for python 3.7
This version of python no longer offers security support, and all our
projects use python 3.8 or 3.9, so we're dropping shuttle support for it.

Bump the package to a higher version
Dropping support for python 3.7 is a big change, so this is needed.