### PR TITLE
chore: Remove support for python 3.8

### DIFF
--- a/Dockerfile-3.8
+++ b/Dockerfile-3.8
@@ -1,8 +1,0 @@
-FROM python:3.8-alpine
-
-RUN mkdir /src
-WORKDIR /src
-COPY . .
-
-RUN python -m pip install -r requirements.txt
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export PYTHON_VERSIONS := 3.8 3.9
+export PYTHON_VERSIONS := 3.9
 
 .PHONY: dev-build
 dev-build: ## Create the docker image for you dev environment.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install hubble_shuttle
 
 ### Supported Python versions
 
-Shuttle is build and tested with Python 3.8, and 3.9.
+Shuttle is build and tested with Python 3.9.
 
 ## Client-level configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,6 @@
 version: "3"
 
 services:
-  hubble-shuttle-3.8:
-    container_name: hubble-shuttle-3.8
-    build:
-      context: .
-      dockerfile: Dockerfile-3.8
-    volumes:
-      - .:/src
-    depends_on:
-      - test_http_server
   hubble-shuttle-3.9:
     container_name: hubble-shuttle-3.9
     build:


### PR DESCRIPTION
This version of python no longer offers security support, and all our projects use python 3.8 or 3.9, so we're dropping shuttle support for it.