### PR TITLE
[sc-17827] Downgrade Shuttle to Python 3.12

### DIFF
--- a/Dockerfile-3.12
+++ b/Dockerfile-3.12
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine as base
+FROM python:3.12-alpine as base
 
 RUN mkdir /src
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ export PYTHON_VERSIONS := 3.12
 
 .PHONY: dev-build
 dev-build: ## Create the docker image for you dev environment.
-	docker-compose build
+	docker compose --profile "*" build
 
 .PHONY: dev-clean
 dev-clean: ## Remove all the docker containers for this project.
-	docker-compose down --rmi local --volumes
+	docker compose --profile "*" down --rmi local --volumes
 
 .PHONY: dev-setup ## Basic environment configuration
 dev-setup:
@@ -15,7 +15,7 @@ dev-setup:
 .PHONY: dev-test
 dev-test: ## Run the tests.
 	for PYTHON_VERSION in ${PYTHON_VERSIONS} ; do \
-		docker-compose run --rm "hubble-shuttle-$$PYTHON_VERSION" python -m unittest discover ; \
+		docker compose run --rm "hubble-shuttle-$$PYTHON_VERSION" python -m unittest discover ; \
 	done
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export PYTHON_VERSIONS := 3.13
+export PYTHON_VERSIONS := 3.12
 
 .PHONY: dev-build
 dev-build: ## Create the docker image for you dev environment.

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ dev-clean: ## Remove all the docker containers for this project.
 dev-setup:
 	build-scripts/ca-certs/export-certs
 
+.PHONY: dev-shell
+dev-shell: ## Start a shell in the dev container
+	docker compose run release sh
+
 .PHONY: dev-test
 dev-test: ## Run the tests.
 	for PYTHON_VERSION in ${PYTHON_VERSIONS} ; do \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install hubble_shuttle
 
 ### Supported Python versions
 
-Shuttle is build and tested with Python 3.13.
+Shuttle is build and tested with Python 3.12.
 
 ## Client-level configuration
 

--- a/build-scripts/ca-certs/export-certs
+++ b/build-scripts/ca-certs/export-certs
@@ -13,7 +13,7 @@ if command -v security 2>&1 >/dev/null
 then
     # macOS: `security` command allows for exporting certs
     echo "Exporting macOS root certificate store to $export_path..."
-    security find-certificate -a -c ysi-YSIFWCERT01-CA -p > $export_path
+    security find-certificate -a -p > $export_path
 else
     echo "Exporting certificates is unsupported on this platform."
     exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
-  hubble-shuttle-3.13:
-    container_name: hubble-shuttle-3.13
+  hubble-shuttle-3.12:
+    container_name: hubble-shuttle-3.12
     build:
       context: .
-      dockerfile: Dockerfile-3.13
+      dockerfile: Dockerfile-3.12
       target: dev
     profiles:
       - dev
@@ -18,7 +18,7 @@ services:
   release:
     build:
       context: .
-      dockerfile: Dockerfile-3.13
+      dockerfile: Dockerfile-3.12
       target: release
     profiles:
       - release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Hubble's Shuttle"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = [
   "requests>2.32.0",
 ]


### PR DESCRIPTION
Since we can't upgrade to Python 3.13, or deploy from a Yardi laptop with the current VPN certificates, we need to step down to Python 3.12.

I also took the chance to clean up our build tools slightly.

- **feat: downgrade to Python 3.12**
- **fix: repair broken make commands**
- **feat: compatibility with Yardi Prisma VPN**
