### PR TITLE
[SC 9929] Migrate to cloud build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,0 @@
-version: 2
-jobs:
-  build:
-    machine: true
-    steps:
-      - checkout
-      - run: make dev-build
-      - run: make dev-test
-

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,10 +5,7 @@ steps:
     args:
       - -c
       - |
-        docker build \
-          --target release \
-          -t ${_DOCKER_TAG} \
-          -f Dockerfile-3.12 \
+        make dev-build
           .
   - id: 'Run tests'
     name: 'gcr.io/cloud-builders/docker'
@@ -16,11 +13,7 @@ steps:
     args:
       - -c
       - |
-        docker compose \
-        --profile release \
-        run \
-        --rm \
-        release python -m unittest discover
+        make dev-test
     waitFor: ['Build image']
 
 substitutions:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,33 @@
+steps:
+  - id: 'Build image'
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'sh'
+    args:
+      - -c
+      - |
+        docker build \
+          --target release \
+          -t ${_DOCKER_TAG} \
+          .
+  - id: 'Run tests'
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'sh'
+    args:
+      - -c
+      - |
+        docker compose \
+        --profile release \
+        run \
+        --rm \
+        release python -m unittest discover
+    waitFor: ['Build image']
+
+substitutions:
+  _SERVICE_NAME: shuttle
+  _BUILD_ID_SHORT: ${BUILD_ID:0:8}
+  _DOCKER_TAG: ${LOCATION}-docker.pkg.dev/${PROJECT_ID}/hubblehq-docker/${_SERVICE_NAME}
+
+options:
+  dynamicSubstitutions: true
+  machineType: 'E2_HIGHCPU_8'
+  logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,7 +8,8 @@ steps:
         docker build \
           --target release \
           -t ${_DOCKER_TAG} \
-          .Dockerfile-3.12
+          -f Dockerfile-3.12 \
+          .
   - id: 'Run tests'
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'sh'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,7 +8,7 @@ steps:
         docker build \
           --target release \
           -t ${_DOCKER_TAG} \
-          .
+          .Dockerfile-3.12
   - id: 'Run tests'
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'sh'


### PR DESCRIPTION
Replaces circle with cloud build for running the tests. 

The tests are a little weird because they rely on an http server to be running, but running our normal dev-test seems to work pretty well.